### PR TITLE
Updating requirment to pin min version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,8 +16,8 @@ requests==2.21.0
 six==1.16.0
 typed-ast==1.5.4
 typing-extensions==3.7.2
-uplink==0.9.7
-uplink-protobuf==0.1.0
+uplink>=0.9.7
+uplink-protobuf>=0.1.0
 uritemplate==3.0.0
 urllib3==1.24.2
 wrapt==1.11.1

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ long_description = read('README.md')
 
 setup(
     name='solaredge_local',
-    version="0.2.1",
+    version="0.2.2",
     url='https://github.com/drobtravels/solaredge-local',
     license='MIT License',
     author='David Roberts',
@@ -35,8 +35,8 @@ setup(
     platforms='any',
     python_requires='>=3.0',
     install_requires=[
-        'uplink',
-        'uplink-protobuf'
+        'uplink>=0.9.7',
+        'uplink-protobuf>=0.1.0'
     ],
     classifiers = [
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
Based on the PR in the HA core, I guess we need to Pin the dependency to a `MIN` version?
- I was able to build
- I was able to generate egg_info

HA Core PR > https://github.com/home-assistant/core/pull/92090