### PR TITLE
Cleanup setup.py and remove lib being imported

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,7 @@
 from __future__ import print_function
-from setuptools import setup, find_packages
+from setuptools import setup
 import io
-import codecs
 import os
-import sys
-
-import solaredge_local
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -22,7 +18,7 @@ long_description = read('README.md')
 
 setup(
     name='solaredge_local',
-    version="0.2.2",
+    version="0.2.3",
     url='https://github.com/drobtravels/solaredge-local',
     license='MIT License',
     author='David Roberts',


### PR DESCRIPTION
Based on recommendation from HA pull request, I removed the cause of the error that dependencies are required before the package is installed! 

Lib was imported and that caused the pip to throw error even before it resolved the dependencies 

I tested:
- I was able to build
- I was able to egg_info
- Installed local copy and saw that dependency packages were installed
- Able to call the API with sample script after installation


I bumped the version also, Hopefully this does it 😄 